### PR TITLE
Støtt separate database-variabler fra Vault

### DIFF
--- a/tester/.env.example
+++ b/tester/.env.example
@@ -1,11 +1,22 @@
 # GraphQL API konfigurasjon
 GRAPHQL_ENDPOINT=https://supergraf-gateway-apollo-functionaltest.sokrates.edupaas.no/graphql
-FS_ADMIN_GRAPHQL=https://studieadm-fs-admin-functionaltest.sokrates.edupaas.no/api/graphql 
+FS_ADMIN_GRAPHQL=https://studieadm-fs-admin-functionaltest.sokrates.edupaas.no/api/graphql
 FS_ADMIN_URL=https://studieadm-fs-admin-functionaltest.sokrates.edupaas.no
 MIN_KOMPETANSE_URL=https://minkompetanse-functionaltest.sokrates.edupaas.no/nb
+
 # Admin Authentication credentials (Feide testbrukere for funksjonelle tester)
 FS_ADMIN_USERNAME=kari456staff
 FS_ADMIN_PASSWORD=098asd
 FS_ADMIN_OVERSTYRT_BRUKER=11906698511:970 422 528
+
 # Playwright konfigurasjon
 BASE_URL=http://localhost:3000
+
+# Database konfigurasjon for krav-parser
+# Verdiene hentes fra Vault: productareas/studieadm/fs/krav-parser/
+# Alternativt kan DATABASE_URL brukes direkte (bakoverkompatibelt)
+DB_HOST=
+DB_PORT=5432
+DB_NAME=
+DB_USR=
+DB_PW=


### PR DESCRIPTION
Oppdaterer krav-parser til å bygge connection string fra separate komponenter (DB_HOST, DB_PORT, DB_NAME, DB_USR, DB_PW) i stedet for å kreve komplett DATABASE_URL. Bakoverkompatibel med DATABASE_URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)