### PR TITLE
Legg til persistente rapporter med tidsstempel

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,27 +29,32 @@ e2e_tests:
     - cd tester
     - apt-get update && apt-get install -y default-jre curl unzip gettext-base jq
     - npm ci
+    # Generate report timestamp (used for Slack links and report organization)
+    - export REPORT_TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)
+    - echo "$REPORT_TIMESTAMP" > report-timestamp.txt
     # Set URLs based on TEST_ENV and write to env file for persistence
     - |
       if [ "$TEST_ENV" = "test" ]; then
-        cat > /tmp/test-env.sh << 'ENVEOF'
+        cat > /tmp/test-env.sh << ENVEOF
       export FS_ADMIN_URL="https://test-fsadmin.sikt.no"
       export FS_ADMIN_GRAPHQL="https://test-fsadmin.sikt.no/api/graphql"
       export MIN_KOMPETANSE_URL="https://test.minkompetanse.no/nb"
       export GRAPHQL_ENDPOINT="https://supergraf-gateway-apollo-test.sokrates.edupaas.no/graphql"
+      export REPORT_TIMESTAMP="$REPORT_TIMESTAMP"
       ENVEOF
       else
-        cat > /tmp/test-env.sh << 'ENVEOF'
+        cat > /tmp/test-env.sh << ENVEOF
       export FS_ADMIN_URL="https://studieadm-fs-admin-functionaltest.sokrates.edupaas.no"
       export FS_ADMIN_GRAPHQL="https://studieadm-fs-admin-functionaltest.sokrates.edupaas.no/api/graphql"
       export MIN_KOMPETANSE_URL="https://minkompetanse-functionaltest.sokrates.edupaas.no/nb"
       export GRAPHQL_ENDPOINT="https://supergraf-gateway-apollo-functionaltest.sokrates.edupaas.no/graphql"
+      export REPORT_TIMESTAMP="$REPORT_TIMESTAMP"
       ENVEOF
       fi
       source /tmp/test-env.sh
       echo "Using TEST_ENV=$TEST_ENV"
       echo "FS_ADMIN_URL=$FS_ADMIN_URL"
-      echo "MIN_KOMPETANSE_URL=$MIN_KOMPETANSE_URL"
+      echo "REPORT_TIMESTAMP=$REPORT_TIMESTAMP"
     # Fetch history from previous successful pipeline
     - mkdir -p allure-results
     - |
@@ -140,6 +145,7 @@ e2e_tests:
     paths:
       - tester/playwright-report/
       - tester/allure-report/
+      - tester/report-timestamp.txt
     reports:
       junit: tester/test-results/junit.xml
     when: always
@@ -155,6 +161,9 @@ build:
   needs:
     - job: e2e_tests
       artifacts: true
+  before_script:
+    - export REPORT_TIMESTAMP=$(cat tester/report-timestamp.txt)
+    - ./scripts/organize-reports.sh reports tester/playwright-report tester/allure-report "$REPORT_TIMESTAMP"
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_PIPELINE_SOURCE == "web"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
 FROM nginx:alpine
 
-# Add the Playwright HTML report at root
-COPY tester/playwright-report/ /usr/share/nginx/html/
+# Install bash for entrypoint script
+RUN apk add --no-cache bash
 
-# Add the Allure report at /allure
-COPY tester/allure-report/ /usr/share/nginx/html/allure/
+# Copy reports to staging directory (will be deployed to persistent volume on startup)
+COPY reports/ /reports-staging/
 
-# nginx config for serving both reports with no-cache headers
+# Copy entrypoint script
+COPY scripts/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# nginx config for serving reports with no-cache headers and directory listing
 RUN echo 'server { \
     listen 80; \
     root /usr/share/nginx/html; \
@@ -16,7 +20,6 @@ RUN echo 'server { \
     location / { \
         autoindex on; \
     } \
-    location /allure/ { \
-        autoindex on; \
-    } \
 }' > /etc/nginx/conf.d/default.conf
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -1,3 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: $CI_ENVIRONMENT_SLUG-reports
+  namespace: $KUBE_NAMESPACE
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -28,6 +40,9 @@ spec:
         ports:
         - name: web
           containerPort: $HTTP_PORT
+        volumeMounts:
+        - name: reports-storage
+          mountPath: /usr/share/nginx/html
         livenessProbe:
           httpGet:
             path: /
@@ -45,3 +60,7 @@ spec:
             memory: 50Mi
           limits:
             memory: 75Mi
+      volumes:
+      - name: reports-storage
+        persistentVolumeClaim:
+          claimName: $CI_ENVIRONMENT_SLUG-reports

--- a/krav/07 Brukeradministrasjon og tilgangsstyring/10 Pålogging/01 Pålogging/feide_innlogging.feature
+++ b/krav/07 Brukeradministrasjon og tilgangsstyring/10 Pålogging/01 Pålogging/feide_innlogging.feature
@@ -1,5 +1,5 @@
 # language: no
-@DEM-INN-FEI-001 @demo @ci
+@DEM-INN-FEI-001 @demo @ci @smoke
 Egenskap: Feide-innlogging
   Som en bruker av FS-systemene
   ønsker jeg å logge inn med Feide

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+# entrypoint.sh
+# Copies new reports to persistent volume and cleans up old ones
+
+set -e
+
+REPORTS_DIR="/usr/share/nginx/html"
+STAGING_DIR="/reports-staging"
+RETENTION_DAYS="${RETENTION_DAYS:-2}"
+
+echo "Starting report deployment..."
+
+# Copy new reports from staging to persistent volume
+if [ -d "$STAGING_DIR" ]; then
+  for dir in "$STAGING_DIR"/*/; do
+    [ -d "$dir" ] || continue
+    dirname=$(basename "$dir")
+    echo "Deploying report: $dirname"
+    rm -rf "${REPORTS_DIR}/${dirname}"
+    cp -r "$dir" "${REPORTS_DIR}/${dirname}"
+  done
+
+  # Copy index file
+  [ -f "$STAGING_DIR/reports-index.json" ] && cp "$STAGING_DIR/reports-index.json" "$REPORTS_DIR/"
+fi
+
+# Clean up reports older than retention period
+echo "Cleaning reports older than $RETENTION_DAYS days..."
+CUTOFF=$(date -d "${RETENTION_DAYS} days ago" +%Y-%m-%d_%H-%M-%S 2>/dev/null || date -v-${RETENTION_DAYS}d +%Y-%m-%d_%H-%M-%S)
+for dir in "${REPORTS_DIR}"/*/; do
+  [ -d "$dir" ] || continue
+  dirname=$(basename "$dir")
+  # Skip 'latest' and any non-timestamp directories
+  if [ "$dirname" != "latest" ] && echo "$dirname" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}_'; then
+    if [ "$dirname" \< "$CUTOFF" ]; then
+      echo "  Removing old report: $dirname"
+      rm -rf "$dir"
+    fi
+  fi
+done
+
+# Update reports index
+echo "Updating reports index..."
+ls -1 "$REPORTS_DIR" 2>/dev/null | grep -E '^[0-9]{4}-[0-9]{2}-[0-9]{2}_|^latest$' | sort -r > /tmp/dirs.txt
+if [ -s /tmp/dirs.txt ]; then
+  # Create JSON array from directory list
+  echo "[" > "${REPORTS_DIR}/reports-index.json"
+  first=true
+  while read -r dir; do
+    if [ "$first" = true ]; then
+      first=false
+    else
+      echo "," >> "${REPORTS_DIR}/reports-index.json"
+    fi
+    printf '  "%s"' "$dir" >> "${REPORTS_DIR}/reports-index.json"
+  done < /tmp/dirs.txt
+  echo "" >> "${REPORTS_DIR}/reports-index.json"
+  echo "]" >> "${REPORTS_DIR}/reports-index.json"
+fi
+
+echo "Report deployment complete. Starting nginx..."
+
+# Start nginx
+exec nginx -g "daemon off;"

--- a/scripts/organize-reports.sh
+++ b/scripts/organize-reports.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# organize-reports.sh
+# Organizes test reports into timestamped folders for Docker build
+
+set -e
+
+REPORTS_DIR="${1:-reports}"
+PLAYWRIGHT_SOURCE="${2:-tester/playwright-report}"
+ALLURE_SOURCE="${3:-tester/allure-report}"
+REPORT_TIMESTAMP="${4:-$(date +%Y-%m-%d_%H-%M-%S)}"
+
+echo "Report timestamp: $REPORT_TIMESTAMP"
+
+# Create reports directory
+mkdir -p "$REPORTS_DIR"
+
+# Copy new reports to timestamped folder
+echo "Creating timestamped report: $REPORT_TIMESTAMP"
+mkdir -p "${REPORTS_DIR}/${REPORT_TIMESTAMP}"
+cp -r "${PLAYWRIGHT_SOURCE}"/* "${REPORTS_DIR}/${REPORT_TIMESTAMP}/"
+mkdir -p "${REPORTS_DIR}/${REPORT_TIMESTAMP}/allure"
+cp -r "${ALLURE_SOURCE}"/* "${REPORTS_DIR}/${REPORT_TIMESTAMP}/allure/"
+
+# Copy to latest (overwrite)
+echo "Updating latest report..."
+rm -rf "${REPORTS_DIR}/latest"
+mkdir -p "${REPORTS_DIR}/latest"
+cp -r "${PLAYWRIGHT_SOURCE}"/* "${REPORTS_DIR}/latest/"
+mkdir -p "${REPORTS_DIR}/latest/allure"
+cp -r "${ALLURE_SOURCE}"/* "${REPORTS_DIR}/latest/allure/"
+
+# Generate reports index
+ls -1 "$REPORTS_DIR" | sort -r > "${REPORTS_DIR}/reports-index.json.tmp"
+echo "[" > "${REPORTS_DIR}/reports-index.json"
+first=true
+while read -r dir; do
+  [ -z "$dir" ] && continue
+  if [ "$first" = true ]; then
+    first=false
+  else
+    echo "," >> "${REPORTS_DIR}/reports-index.json"
+  fi
+  printf '  "%s"' "$dir" >> "${REPORTS_DIR}/reports-index.json"
+done < "${REPORTS_DIR}/reports-index.json.tmp"
+echo "" >> "${REPORTS_DIR}/reports-index.json"
+echo "]" >> "${REPORTS_DIR}/reports-index.json"
+rm "${REPORTS_DIR}/reports-index.json.tmp"
+
+echo "Done! Reports organized in $REPORTS_DIR"

--- a/tester/slack-templates/failed.json
+++ b/tester/slack-templates/failed.json
@@ -48,7 +48,7 @@
             "text": "Playwright Report",
             "emoji": true
           },
-          "url": "https://fs-funksjonelltesting.sokrates.edupaas.no/",
+          "url": "https://fs-funksjonelltesting.sokrates.edupaas.no/${REPORT_TIMESTAMP}/",
           "style": "danger"
         },
         {
@@ -58,7 +58,7 @@
             "text": "Allure Report",
             "emoji": true
           },
-          "url": "https://fs-funksjonelltesting.sokrates.edupaas.no/allure/"
+          "url": "https://fs-funksjonelltesting.sokrates.edupaas.no/${REPORT_TIMESTAMP}/allure/"
         },
         {
           "type": "button",

--- a/tester/slack-templates/passed.json
+++ b/tester/slack-templates/passed.json
@@ -38,7 +38,7 @@
             "text": "Playwright Report",
             "emoji": true
           },
-          "url": "https://fs-funksjonelltesting.sokrates.edupaas.no/",
+          "url": "https://fs-funksjonelltesting.sokrates.edupaas.no/${REPORT_TIMESTAMP}/",
           "style": "primary"
         },
         {
@@ -48,7 +48,7 @@
             "text": "Allure Report",
             "emoji": true
           },
-          "url": "https://fs-funksjonelltesting.sokrates.edupaas.no/allure/"
+          "url": "https://fs-funksjonelltesting.sokrates.edupaas.no/${REPORT_TIMESTAMP}/allure/"
         },
         {
           "type": "button",


### PR DESCRIPTION
- Ny PersistentVolumeClaim for lagring av rapporter
- Entrypoint-script som kopierer rapporter til volume og rydder gamle (>2 dager)
- Slack-meldinger linker til tidsstemplet rapport-URL
- Rapporter tilgjengelig på /{timestamp}/ og /latest/
- Legg til @smoke tag på feide innlogging