### PR TITLE
Legg til API-basert test for opptak-søk

### DIFF
--- a/krav/99 Demo/03 Opptak/01 Opptaksdemo/sok_etter_opptak.feature
+++ b/krav/99 Demo/03 Opptak/01 Opptaksdemo/sok_etter_opptak.feature
@@ -1,0 +1,14 @@
+# language: no
+@DEM-OPT-OPT-003 @demo @e2e @must @planned @nightly
+Egenskap: Søke etter opptak
+  Som søker ønsker jeg å finne publiserte opptak
+  slik at jeg kan søke på aktuelle studieplasser.
+
+  @e2e @planned
+  Scenario: Søke etter et publisert opptak
+    Gitt at jeg er logget inn som person
+    Og at opptaket "Vårsøknad 2025" er publisert
+    Når jeg søker etter "Jordmor" på finn studier
+    Og jeg legger til alle studier i kurven
+    Og jeg går til studiekurven
+    Så skal opptaket være synlig

--- a/tester/fixtures/user-context.ts
+++ b/tester/fixtures/user-context.ts
@@ -21,6 +21,15 @@ export type UserContextManager = {
   readonly currentRole: UserRole
 }
 
+/**
+ * Test-spesifikk data som deles mellom steps i samme scenario.
+ * Automatisk ryddet opp mellom tester.
+ */
+export type TestData = {
+  opptakNavn?: string
+  // Legg til flere felt etter behov
+}
+
 const AUTH_FILES: Record<UserRole, string> = {
   administrator: 'playwright/.auth/fs-admin.json',
   person: 'playwright/.auth/person.json',
@@ -35,7 +44,14 @@ const BASE_URLS: Record<UserRole, string> = {
 
 export const test = base.extend<{
   userContext: UserContextManager
+  testData: TestData
 }>({
+  testData: async ({}, use) => {
+    const data: TestData = {}
+    await use(data)
+    // Data ryddes automatisk opp mellom tester
+  },
+
   userContext: async ({ browser }, use) => {
     const contexts = new Map<UserRole, BrowserContext>()
     const pages = new Map<UserRole, Page>()

--- a/tester/graphql/client.ts
+++ b/tester/graphql/client.ts
@@ -7,6 +7,9 @@ import type {
   AdmissioUtdanningsinstans,
   PersonProfil,
   QueryPersonProfilerFilterInput,
+  OpprettUtdanningstilbudInput,
+  OppdaterUtdanningstilbudV2Payload,
+  OppdaterUtdanningstilbudV2Input,
 } from './types';
 
 if (!process.env.FS_ADMIN_GRAPHQL) {
@@ -93,6 +96,74 @@ export async function opprettOpptak(
   return response.data!.opprettOpptakV2;
 }
 
+export async function opprettUtdanningstilbud(
+  request: APIRequestContext,
+  input: OpprettUtdanningstilbudInput
+): Promise<OppdaterUtdanningstilbudV2Payload> {
+  const response = await graphqlRequest<{ opprettUtdanningstilbudV2: OppdaterUtdanningstilbudV2Payload }>(
+    request,
+    /* GraphQL */ `
+      mutation OpprettUtdanningstilbud($input: OpprettUtdanningstilbudInput!) {
+        opprettUtdanningstilbudV2(input: $input) {
+          errors {
+            ... on Error {
+              message
+              __typename
+            }
+            __typename
+          }
+          utdanningstilbud {
+            id
+            __typename
+          }
+          __typename
+        }
+      }
+    `,
+    { input }
+  );
+
+  if (response.errors?.length) {
+    throw new Error(`GraphQL errors: ${response.errors.map(e => e.message).join(', ')}`);
+  }
+
+  return response.data!.opprettUtdanningstilbudV2;
+}
+
+export async function oppdaterUtdanningstilbud(
+  request: APIRequestContext,
+  input: OppdaterUtdanningstilbudV2Input
+): Promise<OppdaterUtdanningstilbudV2Payload> {
+  const response = await graphqlRequest<{ oppdaterUtdanningstilbudV2: OppdaterUtdanningstilbudV2Payload }>(
+    request,
+    /* GraphQL */ `
+      mutation updateUtdanningstilbudDetails($input: OppdaterUtdanningstilbudV2Input!) {
+        oppdaterUtdanningstilbudV2(input: $input) {
+          errors {
+            ... on Error {
+              message
+              __typename
+            }
+            __typename
+          }
+          utdanningstilbud {
+            id
+            __typename
+          }
+          __typename
+        }
+      }
+    `,
+    { input }
+  );
+
+  if (response.errors?.length) {
+    throw new Error(`GraphQL errors: ${response.errors.map(e => e.message).join(', ')}`);
+  }
+
+  return response.data!.oppdaterUtdanningstilbudV2;
+}
+
 // ============================================================
 // Opptak Queries
 // ============================================================
@@ -168,6 +239,13 @@ export async function hentUtdanningsinstanser(
           organisasjon {
             navn {
               nb
+            }
+          }
+          utdanningsmulighet {
+            navn {
+              nb
+              nn
+              en
             }
           }
           terminFra {


### PR DESCRIPTION
- Ny BDD feature: sok_etter_opptak.feature
- Implementer 'at opptaket {string} er publisert' Given step med GraphQL
- Legg til opprettUtdanningstilbud og oppdaterUtdanningstilbud i client.ts
- Legg til TestData fixture for test-isolasjon

Testen oppretter et komplett opptak med utdanningstilbud via GraphQL API som administrator, bytter til person-kontekst, og verifiserer at opptaket er søkbart og synlig i studiekurven.