### PR TITLE
Legg til feature-filer for administrasjon av API-brukere

### DIFF
--- a/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/administrere_ansvarlig.feature
+++ b/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/administrere_ansvarlig.feature
@@ -1,0 +1,37 @@
+# language: no
+@BRU-APP-API-005 @must @planned
+Egenskap: Administrere ansvarlig for API-bruker
+  Som bruker
+  ønsker jeg å sette og endre ansvarlig for en API-bruker
+  slik at det alltid er klart hvem som er ansvarlig for API-brukeren.
+
+  # Krav fra Confluence: K18 Administrere ansvarlig for API-bruker
+
+  # ÅPNE SPØRSMÅL:
+  # - Feide-grupper som ansvarlig: Skal det være mulig å søke opp og sette en
+  #   feide-gruppe som ansvarlig, som et alternativ til en feide-bruker?
+
+  Scenario: Sette ansvarlig for API-bruker
+    Gitt jeg er på detaljsiden for en API-bruker
+    Og jeg velger å sette ansvarlig
+    Når jeg søker opp og velger en feide-bruker fra API-brukerens organisasjon
+    Så er den valgte feide-brukeren registrert som ansvarlig for API-brukeren
+
+  Scenario: Endre ansvarlig for API-bruker
+    Gitt jeg er på detaljsiden for en API-bruker
+    Og API-brukeren har en ansvarlig
+    Når jeg søker opp og velger en annen feide-bruker fra API-brukerens organisasjon
+    Så er den nye feide-brukeren registrert som ansvarlig for API-brukeren
+
+  Scenario: Fjerne ansvarlig fra API-bruker
+    Gitt jeg er på detaljsiden for en API-bruker
+    Og API-brukeren har en ansvarlig
+    Når jeg fjerner den ansvarlige
+    Så har API-brukeren ikke lenger en ansvarlig registrert
+
+  Regel: Søk etter ansvarlig er avgrenset til API-brukerens organisasjon
+
+    Scenario: Søkeresultat viser kun feide-brukere fra API-brukerens organisasjon
+      Gitt jeg velger å sette ansvarlig på en API-bruker
+      Når jeg søker etter en bruker
+      Så vises kun feide-brukere fra API-brukerens organisasjon i søkeresultatet

--- a/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/api_brukere_med_tilgang_til_larested.feature
+++ b/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/api_brukere_med_tilgang_til_larested.feature
@@ -1,0 +1,13 @@
+# language: no
+@BRU-APP-API-012 @must @planned
+Egenskap: API-brukere med tilgang til lærestedets data
+  Som brukeradministrator på lærested
+  ønsker jeg å se hvilke API-brukere som har tilgang til mitt lærested sine data
+  slik at jeg har kontroll over hvem som har tilgang.
+
+  # Krav fra Confluence: K12 Se API-brukere med tilgang til lærestedets data
+
+  Scenario: Se API-brukere med tilgang til eget lærested
+    Gitt jeg er innlogget som brukeradministrator på lærested
+    Når jeg søker opp API-brukere med tilgang til mitt lærested
+    Så ser jeg alle API-brukere som har tilgang til mitt lærested sine data

--- a/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/deaktivere_api_bruker.feature
+++ b/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/deaktivere_api_bruker.feature
@@ -1,0 +1,14 @@
+# language: no
+@BRU-APP-API-010 @must @planned
+Egenskap: Deaktivere API-bruker
+  Som bruker
+  ønsker jeg å deaktivere en API-bruker
+  slik at en API-bruker som ikke lenger er i bruk ikke kan benyttes.
+
+  # Krav fra Confluence: K9 Deaktivere API-bruker
+
+  Scenario: Deaktivere en aktiv API-bruker
+    Gitt jeg er på detaljsiden for en aktiv API-bruker
+    Når jeg deaktiverer API-brukeren
+    Så er API-brukeren ikke lenger aktiv
+    Og API-brukeren kan ikke benyttes til autentisering

--- a/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/endringslogg.feature
+++ b/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/endringslogg.feature
@@ -1,0 +1,13 @@
+# language: no
+@BRU-APP-API-016 @could @planned
+Egenskap: Endringslogg for API-bruker
+  Som bruker
+  ønsker jeg å se endringslogg over hvem som har endret hva
+  slik at jeg kan spore historikken til en API-bruker.
+
+  # Krav fra Confluence: K16 Se endringslogg (Kan ha)
+
+  Scenario: Se endringslogg
+    Gitt jeg er på detaljsiden for en API-bruker
+    Når jeg åpner endringsloggen
+    Så ser jeg en liste over endringer med hvem som endret og hva som ble endret

--- a/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/fjerne_rolle.feature
+++ b/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/fjerne_rolle.feature
@@ -1,0 +1,16 @@
+# language: no
+@BRU-APP-API-008 @must @planned
+Egenskap: Fjerne rolle fra API-bruker
+  Som intern brukerstøtte
+  ønsker jeg å fjerne en rolle fra en API-bruker
+  slik at API-brukeren mister tilgang til data den ikke lenger skal ha.
+
+  # Krav fra Confluence: K7 Fjerne rolle fra API-bruker
+
+  Regel: Bruker kan kun fjerne roller de har rettigheter til å fjerne
+
+    Scenario: Fjerne en rolle
+      Gitt jeg er på detaljsiden for en API-bruker
+      Og API-brukeren har en rolle jeg har rettighet til å fjerne
+      Når jeg fjerner rollen
+      Så har API-brukeren ikke lenger den valgte rollen

--- a/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/listevisning_og_sok.feature
+++ b/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/listevisning_og_sok.feature
@@ -1,0 +1,68 @@
+# language: no
+@BRU-APP-API-001 @must @planned
+Egenskap: Listevisning og søk i API-brukere
+  Som intern brukerstøtte
+  ønsker jeg en oversikt over alle API-brukere med mulighet for søk og filtrering
+  slik at jeg raskt kan finne og følge opp riktig API-bruker.
+
+  # Krav fra Confluence: K1 Liste over alle API-brukere, K2 Søk og filtrering
+
+  Regel: Liste over alle API-brukere (K1)
+
+    Scenario: Se liste over API-brukere
+      Gitt jeg er innlogget som intern brukerstøtte
+      Når jeg åpner API-brukeroversikten
+      Så ser jeg en liste over alle API-brukere
+      Og listen er sortert etter navn i stigende rekkefølge
+      Og hvert innslag viser følgende informasjon:
+        | felt                |
+        | Navn                |
+        | Beskrivelse         |
+        | Miljøer             |
+        | Ansvarlig           |
+        | Lærested            |
+        | Roller              |
+        | Type API-bruker     |
+        | Oppfølgningsstatus  |
+
+    Scenario: Liste viser de 50 første API-brukerne
+      Gitt jeg er innlogget som intern brukerstøtte
+      Når jeg åpner API-brukeroversikten
+      Så ser jeg totalt antall treff og antall som er lastet
+      Og listen viser de 50 første API-brukerne
+
+    Scenario: Laste inn 50 flere API-brukere
+      Gitt jeg ser listen over API-brukere
+      Og det finnes flere API-brukere enn det som er lastet inn
+      Når jeg velger å laste inn flere
+      Så lastes de neste 50 API-brukerne inn i listen
+
+    Scenario: Alle API-brukere er lastet inn
+      Gitt jeg ser listen over API-brukere
+      Og alle API-brukere er lastet inn
+      Så er muligheten til å laste inn flere ikke tilgjengelig
+
+    Scenario: Navigere til detaljside for API-bruker
+      Gitt jeg ser listen over API-brukere
+      Når jeg velger en API-bruker
+      Så ser jeg detaljsiden for valgt API-bruker
+
+  Regel: Søk og filtrering av API-brukere (K2)
+
+    # ÅPNE SPØRSMÅL:
+    # - Filter på rolle er inkludert i MVP, men kan nedprioriteres dersom kompleksiteten er høy.
+
+    Scenario: Fritekst-søk på navn
+      Gitt jeg ser listen over API-brukere
+      Når jeg søker med fritekst på navn
+      Så filtreres listen til API-brukere som matcher søket
+
+    Scenario: Filtrere på organisasjon
+      Gitt jeg ser listen over API-brukere
+      Når jeg velger en organisasjon som filter
+      Så vises kun API-brukere tilknyttet valgt organisasjon
+
+    Scenario: Kombinere fritekst og organisasjonsfilter
+      Gitt jeg ser listen over API-brukere
+      Når jeg kombinerer fritekst-søk med organisasjonsfilter
+      Så vises kun API-brukere som matcher begge kriteriene

--- a/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/masseadministrasjon_roller.feature
+++ b/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/masseadministrasjon_roller.feature
@@ -1,0 +1,18 @@
+# language: no
+@BRU-APP-API-017 @could @planned
+Egenskap: Masseadministrasjon av roller
+  Som bruker
+  ønsker jeg å se en liste over roller for å tildele eller fjerne én eller flere roller
+  til/fra én eller flere API-brukere.
+
+  # Krav fra Confluence: K17 Masseadministrasjon av roller (Kan ha)
+
+  Scenario: Tildele rolle til flere API-brukere
+    Gitt jeg er på oversiktssiden over roller
+    Når jeg velger en rolle og tildeler den til flere API-brukere
+    Så har alle valgte API-brukere fått rollen
+
+  Scenario: Fjerne rolle fra flere API-brukere
+    Gitt jeg er på oversiktssiden over roller
+    Når jeg velger en rolle og fjerner den fra flere API-brukere
+    Så har ingen av de valgte API-brukerne lenger rollen

--- a/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/opprette_api_bruker.feature
+++ b/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/opprette_api_bruker.feature
@@ -1,0 +1,18 @@
+# language: no
+@BRU-APP-API-009 @must @planned
+Egenskap: Opprette API-bruker
+  Som bruker
+  ønsker jeg å opprette en ny API-bruker
+  slik at nye integrasjoner kan konfigureres.
+
+  # Krav fra Confluence: K8 Opprette ny API-bruker
+
+  Scenario: Opprette en ny API-bruker uten ansvarlig
+    Gitt jeg er innlogget i løsningen
+    Når jeg oppretter en ny API-bruker med navn
+    Så er den nye API-brukeren registrert i systemet
+
+  Scenario: Opprette en ny API-bruker med ansvarlig
+    Gitt jeg er innlogget i løsningen
+    Når jeg oppretter en ny API-bruker og setter en ansvarlig
+    Så er API-brukeren registrert med den valgte feide-brukeren som ansvarlig

--- a/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/oversikt_egne_api_brukere.feature
+++ b/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/oversikt_egne_api_brukere.feature
@@ -1,0 +1,13 @@
+# language: no
+@BRU-APP-API-011 @must @planned
+Egenskap: Oversikt over egne API-brukere
+  Som brukeradministrator på lærested
+  ønsker jeg en oversikt over mine API-brukere
+  slik at jeg kan administrere dem.
+
+  # Krav fra Confluence: K11 Oversikt over egne API-brukere
+
+  Scenario: Se API-brukere tilknyttet eget lærested
+    Gitt jeg er innlogget som brukeradministrator på lærested
+    Når jeg åpner oversikten over API-brukere
+    Så ser jeg kun API-brukere tilknyttet mitt lærested

--- a/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/passordbytte.feature
+++ b/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/passordbytte.feature
@@ -1,0 +1,21 @@
+# language: no
+@BRU-APP-API-004 @must @planned
+Egenskap: Passordbytte for API-bruker
+  Som bruker
+  ønsker jeg å sette nytt passord på en API-bruker jeg har rettighet til å administrere
+  slik at jeg kan hjelpe med passordbytte.
+
+  # Krav fra Confluence: K5 Sette nytt passord på API-bruker
+
+  Regel: Bruker kan kun endre passord på API-brukere de har rettighet til å administrere
+
+    Scenario: Sette nytt passord
+      Gitt jeg er på detaljsiden for en API-bruker
+      Og jeg har rettighet til å endre passord på denne API-brukeren
+      Når jeg setter et nytt passord
+      Så er det nye passordet lagret for API-brukeren
+
+    Scenario: Passordbytte ikke tilgjengelig uten rettighet
+      Gitt jeg er på detaljsiden for en API-bruker
+      Og jeg ikke har rettighet til å endre passord på denne API-brukeren
+      Så er muligheten til å sette nytt passord ikke tilgjengelig

--- a/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/rediger_beskrivelse.feature
+++ b/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/rediger_beskrivelse.feature
@@ -1,0 +1,13 @@
+# language: no
+@BRU-APP-API-006 @must @planned
+Egenskap: Redigere beskrivelse for API-bruker
+  Som bruker
+  ønsker jeg å redigere beskrivelsen for en API-bruker
+  slik at informasjonen er oppdatert og korrekt.
+
+  # Krav fra Confluence: K19 Redigere beskrivelse for API-bruker
+
+  Scenario: Oppdatere beskrivelse
+    Gitt jeg ser detaljer for en API-bruker
+    Når jeg oppdaterer beskrivelsen
+    Så er den nye beskrivelsen lagret på API-brukeren

--- a/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/se_detaljer.feature
+++ b/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/se_detaljer.feature
@@ -1,0 +1,24 @@
+# language: no
+@BRU-APP-API-002 @must @planned
+Egenskap: Se detaljer for API-bruker
+  Som bruker
+  ønsker jeg å se detaljer for en API-bruker, organisert i logiske datagrupper,
+  slik at jeg har oversikt over API-brukeren.
+
+  # Krav fra Confluence: K3 Se detaljer for API-bruker
+
+  Scenario: Se grunnleggende informasjon
+    Gitt jeg ser detaljer for en API-bruker
+    Så ser jeg navn og beskrivelse
+
+  Scenario: Se sporingsinfo
+    Gitt jeg ser detaljer for en API-bruker
+    Så ser jeg opprettet av, opprettet tidspunkt, endret av og endret tidspunkt
+
+  Scenario: Se miljøer
+    Gitt jeg ser detaljer for en API-bruker
+    Så ser jeg hvilke miljøer API-brukeren er aktiv i
+
+  Scenario: Se ansvarlig
+    Gitt jeg ser detaljer for en API-bruker
+    Så ser jeg hvem som er ansvarlig for API-brukeren

--- a/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/selvbetjent_fjerning_rolle.feature
+++ b/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/selvbetjent_fjerning_rolle.feature
@@ -1,0 +1,16 @@
+# language: no
+@BRU-APP-API-014 @must @planned
+Egenskap: Selvbetjent fjerning av rolle
+  Som brukeradministrator
+  ønsker jeg å fjerne en rolle fra en API-bruker
+  slik at roller som ikke lenger er nødvendige blir ryddet bort.
+
+  # Krav fra Confluence: K14 Fjerne rolle fra API-bruker (selvbetjening)
+
+  Regel: Brukeradministrator kan kun fjerne roller de har rettigheter til
+
+    Scenario: Fjerne rolle som brukeradministrator
+      Gitt jeg er innlogget som brukeradministrator på lærested
+      Og API-brukeren har en rolle jeg har rettighet til å fjerne
+      Når jeg fjerner rollen
+      Så har API-brukeren ikke lenger den valgte rollen

--- a/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/selvbetjent_tilordning_rolle.feature
+++ b/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/selvbetjent_tilordning_rolle.feature
@@ -1,0 +1,15 @@
+# language: no
+@BRU-APP-API-013 @must @planned
+Egenskap: Selvbetjent tilordning av rolle
+  Som brukeradministrator på lærested
+  ønsker jeg å tilordne en rolle til en API-bruker fra en liste over roller jeg har rettigheter til å tildele.
+
+  # Krav fra Confluence: K13 Tilordne rolle til API-bruker (selvbetjening)
+
+  Regel: Brukeradministrator kan kun tildele roller de har rettigheter til
+
+    Scenario: Tilordne rolle som brukeradministrator
+      Gitt jeg er innlogget som brukeradministrator på lærested
+      Og jeg er på detaljsiden for en API-bruker
+      Når jeg tilordner en rolle fra listen over tilgjengelige roller
+      Så har API-brukeren fått den valgte rollen

--- a/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/sist_brukt_tidspunkt.feature
+++ b/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/sist_brukt_tidspunkt.feature
@@ -1,0 +1,12 @@
+# language: no
+@BRU-APP-API-015 @could @planned
+Egenskap: Sist brukt tidspunkt
+  Som bruker
+  ønsker jeg å se når API-brukeren ble brukt sist
+  slik at jeg vet om API-brukeren er aktiv.
+
+  # Krav fra Confluence: K15 Se sist brukte tidspunkt (Kan ha)
+
+  Scenario: Se sist brukt tidspunkt på detaljside
+    Gitt jeg er på detaljsiden for en API-bruker
+    Så ser jeg når API-brukeren sist ble brukt til autentisering

--- a/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/tilordne_rolle.feature
+++ b/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/tilordne_rolle.feature
@@ -1,0 +1,21 @@
+# language: no
+@BRU-APP-API-007 @must @planned
+Egenskap: Tilordne rolle til API-bruker
+  Som intern brukerstøtte
+  ønsker jeg å tilordne en rolle til en API-bruker fra en liste over roller jeg har rettigheter til å tildele
+  slik at API-brukeren får tilgang til de dataene den trenger.
+
+  # Krav fra Confluence: K6 Tilordne rolle til API-bruker
+
+  Regel: Bruker kan kun tildele roller de selv har rettigheter til å tildele
+
+    Scenario: Tilordne en rolle
+      Gitt jeg er på detaljsiden for en API-bruker
+      Og jeg ser listen over roller jeg har rettighet til å tildele
+      Når jeg tilordner en rolle til API-brukeren
+      Så har API-brukeren fått den valgte rollen
+
+    Scenario: Tilordne flere roller
+      Gitt jeg er på detaljsiden for en API-bruker
+      Når jeg tilordner flere roller til API-brukeren
+      Så har API-brukeren fått alle de valgte rollene

--- a/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/vise_roller.feature
+++ b/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/01 API-brukere/vise_roller.feature
@@ -1,0 +1,21 @@
+# language: no
+@BRU-APP-API-003 @must @planned
+Egenskap: Vise roller for API-bruker
+  Som bruker
+  ønsker jeg å se hvilke roller en API-bruker har
+  slik at jeg forstår hvilke rettigheter og miljøtilgang API-brukeren er tildelt.
+
+  # Krav fra Confluence: K4 Se roller for API-bruker
+
+  Scenario: Se alle roller for en API-bruker
+    Gitt at tab for å vise roller er aktiv
+    Så ser jeg en liste med alle roller tilknyttet API-brukeren
+    Og liste viser rollekode
+    Og liste viser hvilket miljø rollen gjelder for
+    Og det skal være mulig å filtrere listen på miljø
+    Og det skal være mulig å filtrere listen på roller
+    Og filter for miljø skal gjøre det mulig å filtrere på de miljøene som er tilknyttet brukeren
+    Og filter for roller skal gjøre det mulig å filtrere på de rollene som er tilknyttet brukeren
+    Og det skal være mulig å sortere listen på miljø
+    Og det skal være mulig å sortere listen på rollekode
+    Og dersom listen er mer enn 50 resultater lang så skal det være mulig å laste inn et nytt datasett


### PR DESCRIPTION
Hentet ut krav fra Confluence-siden «Kravspesifikasjon: Grunnleggende selvbetjent administrasjon av API-brukere» (ID 4393271323) og opprettet 17 Gherkin feature-filer under applikasjoner/01 API-brukere/.

Dekker K1–K19 fra kravspesifikasjonen:
- Støttefunksjoner: listevisning, søk, detaljer, roller, passordbytte, ansvarlig og beskrivelse (K1–K5, K18, K19)
- Tilgangsstyring for intern support: tilordne/fjerne rolle, opprette og deaktivere API-bruker (K6–K9)
- Selvbetjening for lærested: oversikt og rolleadministrasjon (K11–K14)
- Nice-to-have: sist brukt, endringslogg, masseadministrasjon (K15–K17)

Feature-IDer bruker konvensjonen @BRU-APP-API-NNN. Åpne spørsmål fra Confluence er inkludert som kommentarer i relevante filer.