### PR TITLE
agents/fs-admin: re-register under ptrhub

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -41,7 +41,7 @@ The canonical registry is the union of `agents/*/AGENT.md` manifests. This table
 
 | Agent ID | Display name | What it does | Status | Joined |
 | --- | --- | --- | --- | --- |
-| [fs-admin](fs-admin/AGENT.md) | FS Admin agent | Owns the React/Next.js admin UI work in the `fs-admin` repo. | active | 2026-05-02 |
+| [fs-admin](fs-admin/AGENT.md) | FS Admin UI agent | Owns the React/Next.js admin UI in the `fs-admin` repo. | active | 2026-05-02 |
 
 Onboarding adds a row here. Removal/retirement updates the `Status` column to `retired` rather than deleting the row, so the registry preserves history.
 

--- a/agents/fs-admin/AGENT.md
+++ b/agents/fs-admin/AGENT.md
@@ -1,10 +1,10 @@
 ---
 id: fs-admin
-display_name: FS Admin agent
+display_name: FS Admin UI agent
 status: active
 joined: 2026-05-02
 ---
-# FS Admin agent
+# FS Admin UI agent
 
 ## What this agent does
 
@@ -12,7 +12,7 @@ Owns the React/Next.js admin UI work in [`fs-admin`](https://gitlab.sikt.no/stud
 
 ## Machine
 
-macOS — operator: mats.myhre@sikt.no.
+macOS — operator: petter.kristiansen@sikt.no.
 
 ## Owns / writes
 


### PR DESCRIPTION
## Summary
- Re-registers the `fs-admin` agent slot under operator `petter.kristiansen@sikt.no` (`ptrhub` on GitHub) via `agent-coord-setup`.
- Renames display from "FS Admin agent" → "FS Admin UI agent" in the manifest and the registry table.

The previous manifest listed `mats.myhre@sikt.no` as operator; the slot has been handed over.

## Test plan
- [x] Local clone configured (`~/Documents/code/fs`, branch `fruitbat`)
- [x] `~/.config/agent-coord.env` written
- [x] `UserPromptSubmit` hook installed in `~/.claude/settings.json`
- [x] Smoke test (`git pull --rebase --autostash`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)