### PR TITLE
Ny skill for designnotater + designnotater for opprette applikasjon

### DIFF
--- a/.claude/skills/utdype-implementasjon/SKILL.md
+++ b/.claude/skills/utdype-implementasjon/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: utdype-implementasjon
+description: Utdyp en eksisterende .feature-fil med UI- og design-patterns i en sidecar-fil (<feature>.design.md). Bruk når brukeren vil "utdype implementasjon", "legge til designdetaljer", "beskrive UI for en feature", eller "lage designnotater" knyttet til et konkret krav. Skillen holder .feature-filen ren BDD (hva) og legger hvordan-detaljer ved siden av.
+---
+
+# Utdype implementasjon
+
+Lag en sidecar-fil `<feature-navn>.design.md` som beskriver UI/design-patterns for en eksisterende `.feature`-fil. Feature-filen forblir uendret.
+
+## Når denne skillen brukes
+
+- Brukeren refererer til en konkret `.feature`-fil og vil utdype hvordan den skal se ut / oppføre seg i UI
+- Domeneeksperter har skrevet hva-et; nå trenger utviklere hvordan-et
+
+## Arbeidsflyt
+
+### 1. Forstå utgangspunktet
+- Les `.feature`-filen som ble pekt ut
+- Identifiser scenarioene og hvilke UI-elementer de implisitt forutsetter (knapper, lister, skjemaer, navigasjon)
+- Sjekk om det finnes en eksisterende `<feature-navn>.design.md` — i så fall, oppdater i stedet for å overskrive
+
+### 2. Identifiser hull
+For hvert scenario, vurder hva som mangler av UI-detaljer:
+- Hvilken sidetype/komponent? (liste, detaljside, modal, wizard)
+- Hva er primær handling? Sekundære handlinger?
+- Hvilke felter vises, og i hvilken rekkefølge?
+- Hvordan håndteres tom tilstand, lasting, feil?
+- Hvilke navigasjons- eller filtreringsmønstre forventes?
+- Hvordan kobles dette til eksisterende komponenter?
+
+### 3. Still målrettede spørsmål
+Bruk `AskUserQuestion` for å avklare. Eksempler:
+- "Hvilken layout brukes for listevisningen — tabell, kort, eller liste?"
+- "Hvor utløses primærhandlingen — toppen av siden, ved hver rad, eller begge?"
+- "Hva skjer ved tom tilstand?"
+
+Spør om én ting av gangen. Ikke gjett — be om svar når noe er uklart.
+
+### 4. Skriv sidecar-filen
+Lagre som `<feature-navn>.design.md` i samme mappe som `.feature`-filen.
+
+Mal:
+
+```markdown
+# Designnotater: <Feature-tittel>
+
+**Relatert feature:** [`<feature-navn>.feature`](./<feature-navn>.feature)
+
+## Overordnet UI-mønster
+
+<Sidetype, hovedlayout, plassering i applikasjonen>
+
+## Komponenter og layout
+
+<Hvilke komponenter, struktur, hierarki — kort og presist>
+
+## Interaksjonsmønstre
+
+### Primærhandling
+<Hva, hvor, hvordan utløses>
+
+### Sekundære handlinger
+<Liste>
+
+### Navigasjon
+<Hvordan kommer brukeren hit, hvor går de videre>
+
+## Tilstander
+
+| Tilstand | UI-håndtering |
+|----------|---------------|
+| Tom | ... |
+| Laster | ... |
+| Feil | ... |
+| Suksess | ... |
+
+## Per-scenario detaljer
+
+### Scenario: <navn fra feature-filen>
+<UI-spesifikke notater som utdyper akkurat dette scenarioet>
+
+## Åpne designspørsmål
+
+- [ ] <spørsmål>
+```
+
+## Konvensjoner
+
+- **Ikke endre `.feature`-filen.** Sidecar-filen er rent tillegg.
+- **Bruk relative lenker** til feature-filen.
+- **Hold det kort.** Notatene skal være lesbare, ikke uttømmende.
+- **Marker uavklarte ting** under "Åpne designspørsmål" — ikke gjett.
+- **Følg terminologi-reglene** i `.claude/rules/gherkin-conventions.md` (organisasjon vs. lærested, osv.)

--- a/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/02 Iterasjon 3 - Grunnleggende tilgangsstyring for intern support/opprette_applikasjon.design.md
+++ b/krav/07 Brukeradministrasjon og tilgangsstyring/applikasjoner/02 Iterasjon 3 - Grunnleggende tilgangsstyring for intern support/opprette_applikasjon.design.md
@@ -1,0 +1,97 @@
+# Designnotater: Opprette applikasjon
+
+**Relatert feature:** [`opprette_applikasjon.feature`](./opprette_applikasjon.feature)
+
+## Overordnet UI-mønster
+
+Opprettelse skjer i en **dialogboks (modal)** som åpnes fra listevisningen for applikasjoner. Alle obligatoriske felter fylles ut i dialogen, og ved vellykket opprettelse lukkes dialogen og brukeren navigeres videre til **detaljsiden for den nyopprettede applikasjonen**.
+
+## Komponenter og layout
+
+Dialogboks med:
+
+- **Tittel:** "Opprett ny applikasjon"
+- **Felter** (alle obligatoriske):
+  - Identitetsleverandør — valg mellom *Feide* og *Maskinporten* (FS skal ikke være valgbar)
+  - Ekstern ID — ID hos valgt identitetsleverandør (verifiseres ved innsending)
+  - Organisasjon — valgliste; antall valg avhenger av rollen:
+    - Tilgang til kun én organisasjon: forhåndsvalgt og låst
+    - Tilgang til flere organisasjoner: valgliste begrenset til disse
+    - Super-applikasjonsadministrator: valgliste over alle organisasjoner
+- **Knapper i bunnen:** *Avbryt* (sekundær) og *Opprett* (primær)
+
+## Interaksjonsmønstre
+
+### Primærhandling
+*Opprett*-knappen sender skjemaet. Verifiserer ekstern ID mot identitetsleverandøren, sjekker unik visningsnavn og unik ID. Ved suksess lukkes dialogen og brukeren navigeres til detaljsiden for applikasjonen.
+
+### Sekundære handlinger
+- *Avbryt* lukker dialogen uten å opprette
+- Lukke dialogen via X eller Escape-tast tilsvarer Avbryt
+
+### Navigasjon
+- **Inn:** Knapp "Opprett applikasjon" i listevisningen åpner dialogen
+- **Ut (suksess):** Automatisk navigasjon til detaljsiden for nyopprettet applikasjon
+- **Ut (avbryt):** Tilbake til listevisningen, ingen endring
+
+## Tilstander
+
+| Tilstand | UI-håndtering |
+|----------|---------------|
+| Tom (åpning) | Identitetsleverandør og organisasjon kan ha forhåndsvalg når det er entydig (én org), ellers tomme felter |
+| Validering | Felt-spesifikke feilmeldinger ved fokus-ut / innsending |
+| Sender | *Opprett*-knappen viser lasting og er deaktivert; dialogen er ikke lukkbar mens forespørselen pågår |
+| Feil (ID ikke funnet) | Feilmelding ved ID-feltet: "ID-en kunne ikke verifiseres hos {identitetsleverandør}" |
+| Feil (ID i bruk) | Feilmelding ved ID-feltet: "ID-en er allerede registrert" |
+| Feil (visningsnavn i bruk) | Feilmelding på toppen av dialogen: "Visningsnavnet «{navn}» er allerede i bruk" — siden navnet hentes fra idP-en, kan brukeren ikke endre det her |
+| Suksess | Dialog lukkes, navigasjon til detaljside, eventuelt toast/banner "Applikasjonen er opprettet" på detaljsiden |
+
+## Per-scenario detaljer
+
+### Scenario: Velge identitetsleverandør ved opprettelse
+Valget mellom Feide og Maskinporten presenteres tydelig (radioknapper eller segmentert kontroll). Etter opprettelse vises identitetsleverandøren som låst/skrivebeskyttet på detaljsiden.
+
+### Scenario: FS er ikke en valgbar identitetsleverandør
+FS skal ikke vises som alternativ i dialogen i det hele tatt.
+
+### Scenario: Opprette applikasjon når administrator har tilgang til kun én organisasjon
+Organisasjonsfeltet er forhåndsvalgt med administratorens eneste organisasjon og kan ikke endres.
+
+### Scenario: Opprette applikasjon når administrator har tilgang til flere organisasjoner
+Organisasjonsfeltet er en valgliste begrenset til administratorens organisasjoner.
+
+### Scenario: Super-applikasjonsadministrator velger blant alle organisasjoner
+Organisasjonsfeltet viser alle organisasjoner i systemet, med søk i lista hvis antallet er stort.
+
+### Scenariomal: Opprette applikasjon med ekstern identitet
+Visningsnavnet hentes fra idP-en ved innsending — det vises *ikke* som et redigerbart felt i dialogen. Etter suksess vises det fulle navnet på detaljsiden.
+
+### Scenariomal: Opprettelse avvises når ID ikke finnes hos kilden
+Verifisering skjer ved innsending (ikke under skriving), siden den krever et oppslag mot idP-en. Feilmelding plasseres ved ID-feltet.
+
+### Scenariomal: Opprettelse avvises når ID allerede er registrert
+Samme behandling som "ID ikke funnet" — feilmelding ved ID-feltet, men med annen tekst.
+
+### Scenario: Intern ID genereres ved opprettelse
+Den interne ID-en vises ikke i dialogen, men kan vises på detaljsiden etter opprettelse.
+
+### Scenariomal: Opprettelse avvises når visningsnavn allerede er i bruk
+Feilmeldingen plasseres på toppen av dialogen, ikke ved et felt — fordi visningsnavnet ikke er et felt brukeren har fylt ut. Teksten må forklare at navnet hentes fra idP-en og foreslå hva brukeren kan gjøre (f.eks. bytte navn i idP-en eller kontakte eier av eksisterende applikasjon).
+
+### Scenario: Nyopprettet applikasjon er ikke aktiv i noen miljøer
+Detaljsiden viser tydelig at applikasjonen ikke er aktiv i noen miljøer og hva som må til for å aktivere den (tildele tilgang).
+
+### Scenario: Nyopprettet applikasjon kan autentisere umiddelbart
+Vurder en informasjonsboks på detaljsiden som forklarer at applikasjonen kan autentisere, men ikke får data før den får tilgang i et miljø.
+
+## Avklarte valg
+
+- **IdP-velger:** Radioknapper med Feide og Maskinporten
+- **Organisasjonsvelger:** Vanlig nedtrekksliste (uten søk), også for super-applikasjonsadministrator
+- **Plassering av "Opprett applikasjon"-knapp:** I `ActionButtons`-slot i `ListPageLayout` (etablert prosjektmønster for handlinger i listevisninger)
+- **Suksess-feedback:** Toast/snackbar på detaljsiden etter navigasjon ("Applikasjonen er opprettet")
+- **Lasting under idP-verifisering:** Spinner i *Opprett*-knappen; knappen deaktiveres og dialogen kan ikke lukkes mens forespørselen pågår
+
+## Åpne designspørsmål
+
+Ingen utestående.


### PR DESCRIPTION
## Summary
- Ny skill `utdype-implementasjon` som lager sidecar-fil `<feature>.design.md` med UI- og design-patterns for en eksisterende `.feature`-fil
- Designnotater for `opprette_applikasjon.feature` (applikasjoner – iterasjon 3): dialog med obligatoriske felter, suksess → naviger til detaljside, alle 5 designvalg avklart

## Test plan
- [ ] Skillen dukker opp i listen og kan trigges via `/utdype-implementasjon`
- [ ] Designnotatene leses godt sammen med feature-filen

🤖 Generated with [Claude Code](https://claude.com/claude-code)